### PR TITLE
feat: proposal command bang support (suppress echo)

### DIFF
--- a/plugin/findroot.vim
+++ b/plugin/findroot.vim
@@ -55,7 +55,7 @@ function! s:findroot(echo) abort
   endif
 endfunction
 
-command! -bar FindRoot call s:findroot(1)
+command! -bang -bar FindRoot call s:findroot(empty('<bang>') ? 1 : 0)
 
 augroup FindRoot
   au!


### PR DESCRIPTION
# Currently
`s:findroot()` intenal function support echo on/off.
But command only echo on.

# Propsal
Add bang(!) support for echo on/off

Pros.
- already echo toggle using

Cons.
- see alternative

# Alternative
Use `silent! FindRoot`, bang other function.

Choose this PR or not?